### PR TITLE
Correct search pattern for e2eTest

### DIFF
--- a/app/templates/_test.js
+++ b/app/templates/_test.js
@@ -15,7 +15,7 @@ var gulp = require('gulp')
 
   , unitTests = '{app,test}/**/*_test.*'
 
-  , e2eTestFiles = 'e2e/**/*';
+  , e2eTestFiles = 'e2e/**/*_test.*';
 
 // inject scripts in karma.config.js
 gulp.task('karmaInject', function () {


### PR DESCRIPTION
`e2eTestFiles` should only pick up tests file, not other auxiliary modules.

This PR should fix https://github.com/dustinspecker/generator-ng-poly/issues/49 
