### PR TITLE
adding caching for js and css

### DIFF
--- a/app/templates/_build.js
+++ b/app/templates/_build.js
@@ -72,6 +72,7 @@ gulp.task('styles', ['clean'], function () {
     appStyleFiles<% if (polymer) { %>,
     '!' + appComponents<% } %>
   ])
+    .pipe($.cached('styles'))
     .pipe($.plumber({errorHandler: onError}))
     .pipe(lessFilter)
     .pipe($.less())
@@ -102,6 +103,7 @@ gulp.task('scripts', ['clean', 'analyze', 'markup'], function () {
     '!**/*_test.*',
     '!**/index.html'
   ])
+    .pipe($.cached('scripts'))
     .pipe(coffeeFilter)
     .pipe($.coffee())
     .pipe(coffeeFilter.restore())

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,6 +16,7 @@
     "gulp-add-src": "^0.2.0"<% } %>,
     "gulp-angular-filesort": "git://github.com/dustinspecker/gulp-angular-filesort.git#coffee-script",
     "gulp-autoprefixer": "^2.0.0",
+    "gulp-cached": "^1.0.1",
     "gulp-coffee": "^2.1.2",
     "gulp-coffeelint": "~0.4.0",
     "gulp-concat": "^2.3.4",


### PR DESCRIPTION
This prevents unmodified files from being processed. Speeds up development process by not having to wait for all files to be rebuilt
