### PR TITLE
use upstream gulp-angular-filesort instead

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -14,7 +14,7 @@
     "glob": "^4.0.6",
     "gulp": "^3.8.7"<% if (polymer) { %>,
     "gulp-add-src": "^0.2.0"<% } %>,
-    "gulp-angular-filesort": "git://github.com/dustinspecker/gulp-angular-filesort.git#coffee-script",
+    "gulp-angular-filesort": "^1.0.4",
     "gulp-autoprefixer": "^2.0.0",
     "gulp-coffee": "^2.1.2",
     "gulp-coffeelint": "~0.4.0",


### PR DESCRIPTION
https://github.com/dustinspecker/generator-ng-poly/issues/91

Now that we only sort JS files, there is no need to use the patched
version for CoffeeScript.