### PR TITLE
better way to reuse built templates for test

### DIFF
--- a/app/templates/_build.config.js
+++ b/app/templates/_build.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var outDir = 'build/';
+
 module.exports = {
   host: '<%= host %>',
   port: <%= port %>,
@@ -10,15 +12,18 @@ module.exports = {
   // unit test directories
   unitTestDir: '<%= unitTestDir %>',
 
+  // build test dir
+  buildTestDir: outDir + 'test/',
+
   // build directories
-  buildDir: 'build/',<% if (polymer) { %>
-  buildComponents: 'build/components/',<% } %>
-  buildCss: 'build/css/',
-  buildFonts: 'build/fonts/',
-  buildImages: 'build/images/',
-  buildJs: 'build/js/',
-  extDir: 'build/vendor/',
-  extCss: 'build/vendor/css/',
-  extFonts: 'build/vendor/fonts/',
-  extJs: 'build/vendor/js/'
+  buildDir: outDir + '<%= appDir %>/',<% if (polymer) { %>
+  buildComponents: outDir + '<%= appDir %>/components/',<% } %>
+  buildCss: outDir + '<%= appDir %>/css/',
+  buildFonts: outDir + '<%= appDir %>/fonts/',
+  buildImages: outDir + '<%= appDir %>/images/',
+  buildJs: outDir + '<%= appDir %>/js/',
+  extDir: outDir + '<%= appDir %>/vendor/',
+  extCss: outDir + '<%= appDir %>/vendor/css/',
+  extFonts: outDir + '<%= appDir %>/vendor/fonts/',
+  extJs: outDir + '<%= appDir %>/vendor/js/'
 };

--- a/app/templates/_build.js
+++ b/app/templates/_build.js
@@ -300,7 +300,19 @@ gulp.task('images', ['clean'], function () {
     .pipe(gulp.dest(buildConfig.buildImages));
 });
 
-gulp.task('deleteTemplates', [<% if (polymer) { %>'components'<% } else { %>'bowerInject'<% } %>], function (cb) {
+gulp.task('copyTemplates', [<% if (polymer) { %>'components'<% } else { %>'bowerInject'<% } %>], function () {
+  // always copy templates to testBuild directory
+  var buildDirectiveTemplateFiles = path.join(buildConfig.buildDir, '**/*directive.tpl.html')
+    , testDirectiveTemplateDir = path.join(buildConfig.buildTestDir, 'templates')
+    , stream = $.streamqueue({objectMode: true});
+
+  stream.queue(gulp.src([buildDirectiveTemplateFiles]));
+
+  return stream.done()
+    .pipe(gulp.dest(testDirectiveTemplateDir));
+});
+
+gulp.task('deleteTemplates', ['copyTemplates'], function (cb) {
   // only delete templates in production
   // the templates are injected into the app during prod build
   if (!isProd) {

--- a/app/templates/_karma.config.js
+++ b/app/templates/_karma.config.js
@@ -3,22 +3,32 @@ var buildConfig = require('./build.config.js')
   , isProd = require('yargs').argv.stage === 'prod'
   , preprocessors = {}
   , buildDir
+  , buildTestDir
+  , templateDir
   , jsDir;
 
-buildDir = (isProd ? 'tmp/' : '') + buildConfig.buildDir;
+buildDir = buildConfig.buildDir;
 // add slash if missing to properly strip prefix from directive templates
 if (buildDir[buildDir.length - 1] !== '/') {
   buildDir = buildDir + '/';
 }
 
-jsDir = 'tmp/' + buildConfig.buildJs;
+buildTestDir = buildConfig.buildTestDir;
+// add slash if missing to properly strip prefix from directive templates
+if (buildTestDir[buildTestDir.length - 1] !== '/') {
+  buildTestDir = buildTestDir + '/';
+}
+
+templateDir = buildTestDir + 'templates/';
+
+jsDir = buildConfig.buildJs;
 // add slash if missing to properly strip prefix from directive templates
 if (jsDir[jsDir.length - 1] !== '/') {
   jsDir = jsDir + '/';
 }
 
 preprocessors[jsDir + '**/*.js)'] = ['coverage'];
-preprocessors[buildDir + '**/*-directive.tpl.html'] = ['ng-html2js'];
+preprocessors[templateDir + '**/*-directive.tpl.html'] = ['ng-html2js'];
 
 module.exports = {
   browsers: ['PhantomJS'],

--- a/app/templates/_test.js
+++ b/app/templates/_test.js
@@ -18,11 +18,11 @@ var gulp = require('gulp')
   , buildJsFiles = path.join(buildConfig.buildJs, '**/*.js')
 
   , unitTests = path.join(buildConfig.unitTestDir, '**/*_test.*')
-  , compiledUnitTestsDir = path.join('tmp', buildConfig.unitTestDir)
+  , compiledUnitTestsDir = path.join(buildConfig.buildTestDir, buildConfig.unitTestDir)
   , compiledUnitTests = path.join(compiledUnitTestsDir, '**/*_test.js')
   , e2eFiles = 'e2e/**/*'
-  , compiledE2eTestsDir = 'tmp/e2e/'
-  , compiledE2eTests = compiledE2eTestsDir + '**/*_test.*'
+  , compiledE2eTestsDir = path.join(buildConfig.buildTestDir, 'e2e/')
+  , compiledE2eTests = path.join(compiledE2eTestsDir, '**/*_test.*')
 
   , karmaConf = require('../karma.config.js')
 
@@ -36,13 +36,8 @@ var gulp = require('gulp')
 // karmaConf.files get populated in karmaFiles
 karmaConf.files = [];
 
-// production builds move templates to tmp/
-if (isProd) {
-  buildDirectiveTemplateFiles = 'tmp/' + buildDirectiveTemplateFiles;
-}
-
 gulp.task('clean:test', function (cb) {
-  return $.del('tmp', cb);
+  return $.del(buildConfig.buildTestDir, cb);
 });
 
 gulp.task('buildTests', ['lint', 'clean:test'], function () {


### PR DESCRIPTION
    + Build as normal to `build/app1`
    + copy built templates files to `build/test/templates` just for test

That way I don't think we ever need to rebuilt anything unesscessary,
remove tmp directory and allow test to run without the need to know if
the build is prod or dev.