### PR TITLE
fix missing angular plugin declaration at eslintrc

### DIFF
--- a/app/templates/.eslintrc
+++ b/app/templates/.eslintrc
@@ -5,6 +5,9 @@
   "globals": {
     "angular": true
   },
+  "plugins": [
+    "angular"
+  ],
   "rules": {
     "angular/ng_angularelement": [2, true],
     "angular/ng_controller_name": [2, "/[A-Z].*Ctrl$/"],


### PR DESCRIPTION
without this fix, I got this error in console when started gulp tasks

`Error: Definition for rule 'angular/ng_angularelement' was not found.`