### PR TITLE
[Issue 134] Fix error when running gulp unitTest

### DIFF
--- a/app/templates/gulp/_test.js
+++ b/app/templates/gulp/_test.js
@@ -94,7 +94,9 @@ gulp.task('karmaFiles', ['build', 'buildTests'], function () {
 
 // run unit tests
 gulp.task('unitTest', ['lint', 'karmaFiles'], function (done) {
-  $.karma.server.start(karmaConf, done);
+  $.karma.server.start(karmaConf, function() {
+    done()
+  });
 });
 
 gulp.task('build:e2eTest', function () {


### PR DESCRIPTION
Error appears to only occur with gulp 3.8.9+

This fixes issue #134 