### PR TITLE
fix problem with appComponents

### DIFF
--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -21,7 +21,7 @@ module.exports = function (gulp, $, config) {
 
     return gulp.src([
       config.appMarkupFiles<% if (polymer) { %>,
-      '!' + appComponents<% } %>
+      '!' + config.appComponents<% } %>
     ])
       .pipe(hamlFilter)
       .pipe($.haml())
@@ -40,7 +40,7 @@ module.exports = function (gulp, $, config) {
 
     return gulp.src([
       config.appStyleFiles<% if (polymer) { %>,
-      '!' + appComponents<% } %>
+      '!' + config.appComponents<% } %>
     ])
       .pipe($.plumber({errorHandler: function (err) {
         $.notify.onError({
@@ -102,7 +102,7 @@ module.exports = function (gulp, $, config) {
     return gulp.src([
       config.appScriptFiles,
       config.buildDir + '**/*.html'<% if (polymer) { %>,
-      '!' + appComponents<% } %>,
+      '!' + config.appComponents<% } %>,
       '!**/*_test.*',
       '!**/index.html'
     ])
@@ -255,7 +255,7 @@ module.exports = function (gulp, $, config) {
       , scssFilter = $.filter('**/*.scss')
       , stylFilter = $.filter('**/*.styl');
 
-    return gulp.src(appComponents)
+    return gulp.src(config.appComponents)
       .pipe($.addSrc(bowerDir + 'polymer/{layout,polymer}.{html,js}', {base: bowerDir}))
       .pipe(es6Filter)
       .pipe($.babel())


### PR DESCRIPTION
// stacktrace by calling gulp
ReferenceError: appComponents is not defined
  at Gulp.<anonymous> (/Users/DS/TX/artium/gulp/build.js:24:13)
  at module.exports (/Users/DS/TX/artium/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:34:7)
  at Gulp.Orchestrator._runTask (/Users/DS/TX/artium/node_modules/gulp/node_modules/orchestrator/index.js:273:3)
  at Gulp.Orchestrator._runStep (/Users/DS/TX/artium/node_modules/gulp/node_modules/orchestrator/index.js:214:10)
  at /Users/DS/TX/artium/node_modules/gulp/node_modules/orchestrator/index.js:279:18
  at finish (/Users/DS/TX/artium/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:21:8)
  at cb (/Users/DS/TX/artium/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:29:3)
  at /Users/DS/TX/artium/node_modules/del/index.js:54:4
  at callback (/Users/DS/TX/artium/node_modules/del/node_modules/each-async/index.js:38:4)
  at /Users/DS/TX/artium/node_modules/del/node_modules/each-async/node_modules/onetime/index.js:20:12
  at next (/Users/DS/TX/artium/node_modules/del/node_modules/rimraf/rimraf.js:70:7)
  at FSReqWrap.CB [as oncomplete] (/Users/DS/TX/artium/node_modules/del/node_modules/rimraf/rimraf.js:106:9)

// .yo-rc.json
{
  "generator-ng-poly": {
    "appScript": "es6",
    "controllerAs": true,
    "e2eTestFramework": "mocha",
    "markup": "jade",
    "ngRoute": false,
    "structure": "module-only",
    "style": "styl",
    "testFramework": "mocha",
    "testScript": "es6",
    "lastUsedModule": "home"
  }
}