### PR TITLE
Add missing runtime es6 babel-core polyfill (e.g. Symbol) lib to karma, ...

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -56,6 +56,7 @@
     "karma": "^0.12.16"<% if (testFramework === 'mocha') { %>,
     "karma-chai": "^0.1.0"<% } %>,
     "karma-coverage": "^0.2.5",
+    "karma-babel-preprocessor": "^5.1.0",
     "karma-failed-reporter": "^0.0.3"<% if (testFramework === 'jasmine') { %>,
     "karma-jasmine": "^0.3.0"<% } else if (testFramework === 'mocha') { %>,
     "karma-mocha": "^0.1.9"<% } %>,

--- a/app/templates/gulp/_test.js
+++ b/app/templates/gulp/_test.js
@@ -3,7 +3,9 @@
 var karmaConf = require('../karma.config.js');
 
 // karmaConf.files get populated in karmaFiles
-karmaConf.files = [];
+karmaConf.files = [
+  'node_modules/karma-babel-preprocessor/node_modules/babel-core/browser-polyfill.js'
+];
 
 module.exports = function (gulp, $, config) {
   gulp.task('clean:test', function (cb) {


### PR DESCRIPTION
...to allow testing in PhantomJS or IE