### PR TITLE
Add .woff2 file extension to 'bowerAssets' and 'fonts' gulp tasks.

### DIFF
--- a/lib/app/templates/gulp/_build.js
+++ b/lib/app/templates/gulp/_build.js
@@ -295,7 +295,7 @@ module.exports = function (gulp, $, config) {
 
   // copy Bower fonts and images into build directory
   gulp.task('bowerAssets', ['clean'], function () {
-    var assetFilter = $.filter('**/*.{eot,otf,svg,ttf,woff,gif,jpg,jpeg,png}', {restore: true});
+    var assetFilter = $.filter('**/*.{eot,otf,svg,ttf,woff,woff2,gif,jpg,jpeg,png}', {restore: true});
     return gulp.src($.mainBowerFiles(), {base: bowerDir})
       .pipe(assetFilter)
       .pipe(gulp.dest(config.extDir))
@@ -304,7 +304,7 @@ module.exports = function (gulp, $, config) {
 
   // copy custom fonts into build directory
   gulp.task('fonts', ['clean'], function () {
-    var fontFilter = $.filter('**/*.{eot,otf,svg,ttf,woff}', {restore: true});
+    var fontFilter = $.filter('**/*.{eot,otf,svg,ttf,woff,woff2}', {restore: true});
     return gulp.src([config.appFontFiles])
       .pipe(fontFilter)
       .pipe(gulp.dest(config.buildFonts))


### PR DESCRIPTION
Fixes #185