### PR TITLE
Change 'module' to 'angular.mock.module' in unit tests for TypeScript

### DIFF
--- a/lib/constant/templates/_spec.ts
+++ b/lib/constant/templates/_spec.ts
@@ -6,7 +6,7 @@
 describe('<%= lowerCamel %>', function () {
   var constant;
 
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
 
   beforeEach(inject(function (<%= lowerCamel %>) {
     constant = <%= lowerCamel %>;

--- a/lib/controller/templates/_spec.ts
+++ b/lib/controller/templates/_spec.ts
@@ -6,7 +6,7 @@
 describe('<%= ctrlName %>', function () {
   <% if (controllerAs) { %>var ctrl;<% } else { %>var scope;<% } %>
 
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
 
   beforeEach(inject(function ($rootScope, $controller) {
     <% if (controllerAs) { %>ctrl = $controller('<%= ctrlName %>');<% } else { %>scope = $rootScope.$new();

--- a/lib/decorator/templates/_spec.ts
+++ b/lib/decorator/templates/_spec.ts
@@ -6,7 +6,7 @@
 describe('<%= name %>', function () {
   var decorator;
 
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
 
   beforeEach(inject(function (<%= name %>) {
     decorator = <%= name %>;

--- a/lib/directive/templates/_spec.ts
+++ b/lib/directive/templates/_spec.ts
@@ -7,7 +7,7 @@ describe('<%= lowerCamel %>', function () {
   var scope
     , element;
 
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'<% if (directiveTemplateUrl) { %>, '<%= templateUrl %>/<%= hyphenName %>-directive.tpl.html'<% } %>));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'<% if (directiveTemplateUrl) { %>, '<%= templateUrl %>/<%= hyphenName %>-directive.tpl.html'<% } %>));
 
   beforeEach(inject(function ($compile, $rootScope) {
     scope = $rootScope.$new();

--- a/lib/factory/templates/_spec.ts
+++ b/lib/factory/templates/_spec.ts
@@ -6,7 +6,7 @@
 describe('<%= upperCamel %>', function () {
   var factory;
 
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
 
   beforeEach(inject(function (<%= upperCamel %>) {
     factory = <%= upperCamel %>;

--- a/lib/filter/templates/_spec.ts
+++ b/lib/filter/templates/_spec.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 describe('<%= lowerCamel %>', function () {
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
 
   it('should filter our numbers not greater than 3', inject(function ($filter) {
     expect($filter('<%= lowerCamel %>')([1, 2, 3, 4])).<% if (testFramework === 'mocha') { %>to.include.members<% } else { %>toEqual<% } %>([4]);

--- a/lib/provider/templates/_spec.ts
+++ b/lib/provider/templates/_spec.ts
@@ -6,7 +6,7 @@
 describe('<%= upperCamel %>', function () {
   var provider;
 
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
 
   beforeEach(inject(function (<%= upperCamel %>) {
     provider = <%= upperCamel %>;

--- a/lib/service/templates/_spec.ts
+++ b/lib/service/templates/_spec.ts
@@ -6,7 +6,7 @@
 describe('<%= upperCamel %>', function () {
   var service;
 
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
 
   beforeEach(inject(function (<%= upperCamel %>) {
     service = <%= upperCamel %>;

--- a/lib/value/templates/_spec.ts
+++ b/lib/value/templates/_spec.ts
@@ -6,7 +6,7 @@
 describe('<%= lowerCamel %>', function () {
   var value;
 
-  beforeEach(module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
+  beforeEach(angular.mock.module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>'));
 
   beforeEach(inject(function (<%= lowerCamel %>) {
     value = <%= lowerCamel %>;

--- a/test/test-directive.js
+++ b/test/test-directive.js
@@ -124,7 +124,7 @@ describe('Directive generator', () => {
 
       it('should inject template module in spec', () => {
         assert.fileContent('app/home/directives/test3-with-url-directive_test.ts',
-          `beforeEach(module('home', 'home/directives/test3-with-url-directive.tpl.html'));`);
+          `beforeEach(angular.mock.module('home', 'home/directives/test3-with-url-directive.tpl.html'));`);
       });
     });
 
@@ -296,7 +296,7 @@ describe('Directive generator', () => {
 
       it('should not inject template module', () => {
         assert.fileContent('app/home/directives/test3-with-inline-directive_test.ts',
-          `beforeEach(module('home'));`);
+          `beforeEach(angular.mock.module('home'));`);
       });
     });
 


### PR DESCRIPTION
Fixes #189