### PR TITLE
Added typedef to $inject on controller and service templates

### DIFF
--- a/lib/controller/templates/_controller.ts
+++ b/lib/controller/templates/_controller.ts
@@ -10,7 +10,7 @@ module <%= ctrlName %> {
     // It provides $injector with information about dependencies to be injected into constructor
     // it is better to have it close to the constructor, because the parameters must match in count and type.
     // See http://docs.angularjs.org/guide/di
-    public static $inject = [<% if (!controllerAs) { %>
+    public static $inject: Array<string> = [<% if (!controllerAs) { %>
       '$scope' <% } %>
     ];
 

--- a/lib/service/templates/_service.ts
+++ b/lib/service/templates/_service.ts
@@ -3,7 +3,7 @@ module <%= upperCamel %> {
   'use strict';
 
   class <%= upperCamel %> {
-    public static $inject = [
+    public static $inject: Array<string> = [
     ];
 
     constructor() {


### PR DESCRIPTION
#### What does this PR do?
This fixes the typedef error thrown by TSLint on $inject variables.

The variable always expect an array of strings.