### PR TITLE
Issue 316

### DIFF
--- a/lib/controller/templates/_controller.ts
+++ b/lib/controller/templates/_controller.ts
@@ -10,7 +10,7 @@ module <%= ctrlName %> {
     // It provides $injector with information about dependencies to be injected into constructor
     // it is better to have it close to the constructor, because the parameters must match in count and type.
     // See http://docs.angularjs.org/guide/di
-    public static $inject = [<% if (!controllerAs) { %>
+    public static $inject: Array<string> = [<% if (!controllerAs) { %>
       '$scope' <% } %>
     ];
 

--- a/lib/directive/templates/_directive.ts
+++ b/lib/directive/templates/_directive.ts
@@ -28,12 +28,12 @@ module <%= upperCamel %> {
         export class <%= upperCamel %>Controller {
             public name: string;
             public static $inject: Array<string> = [];
+
             constructor() {
                 this.name = '<%= lowerCamel %>';
             }
         }
     <% } %>
-
     /**
     * @ngdoc directive
     * @name <% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>.directive:<%= lowerCamel %>

--- a/lib/directive/templates/_directive.ts
+++ b/lib/directive/templates/_directive.ts
@@ -1,51 +1,52 @@
 ///<reference path='<%= referencePath %>' />
-function <%= upperCamel %>Directive(): ng.IDirective {
-  'use strict';
-  return {
-        restrict: 'EA',
-        scope: {},<% if (directiveTemplateUrl) { %>
-        templateUrl: '<%= templateUrl %>/<%= hyphenName %>-directive.tpl.html'<% } else { %>,
-        template: '<div>{{<%= lowerCamel %>.name}}</div>'<% } %>,
-        replace: false,<% if (controllerAs) { %>
-        controllerAs: '<%= lowerCamel %>',
-        controller: function (<% if (!controllerAs) { %>$scope: ng.IScope<% } %>) {
-        <% if (controllerAs) { %>var vm = this;
-            vm.name = '<%= lowerCamel %>';<% } else { %>$scope.<%= lowerCamel %> = {};
-            $scope.<%= lowerCamel %>.name = '<%= lowerCamel %>';<% } %>
-    },
-    link: (scope: ng.IScope, element: JQuery, attrs: ng.IAttributes): void => {
-      /*jshint unused:false */
-      /*eslint "no-unused-vars": [2, {"args": "none"}]*/
+module <%= upperCamel %> {
+    'use strict';
+
+    function <%= upperCamel %>Directive(): ng.IDirective {
+        return {
+            restrict: 'EA',
+            scope: {}<% if (directiveTemplateUrl) { %>,
+            templateUrl: '<%= templateUrl %>/<%= hyphenName %>-directive.tpl.html'<% } else { %>,
+            template: '<div>{{<%= lowerCamel %>.name}}</div>'<% } %>,
+            replace: false,<% if (controllerAs) { %>
+            controllerAs: '<%= lowerCamel %>',<% } %>
+            controller: function (<% if (!controllerAs) { %>$scope: ng.IScope<% } %>) {
+                <% if (controllerAs) { %>var vm = this;
+                vm.name = '<%= lowerCamel %>';<% } else { %>$scope.<%= lowerCamel %> = {};
+                $scope.<%= lowerCamel %>.name = '<%= lowerCamel %>';<% } %>
+            },
+            link: function (scope: ng.IScope, element: JQuery, attrs: any) {
+                /*jshint unused:false */
+                /*eslint "no-unused-vars": [2, {"args": "none"}]*/
+            }
+        }
     }
-  }
-}
-  <% if (!controllerAs) { %>
-    module <%= upperCamel %> {
-          'use strict';
-  export class <%= upperCamel %>Controller {
-    public static $inject: Array<string> = [];
-      constructor() {
-        /*jshint unused:false */
-      }
-    }
-  }
+    <% if (!controllerAs) { %>
+        export class <%= upperCamel %>Controller {
+            public static $inject: Array<string> = [];
+            constructor() {
+                /*jshint unused:false */
+            }
+        }
     <% } %>
-  /**
-   * @ngdoc directive
-   * @name <% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>.directive:<%= lowerCamel %>
-   * @restrict EA
-   * @element
-   *
-   * @description
-   *
-   * @example
-   <example module="<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>">
-   <file name="index.html">
-   <<%= hyphenName %>></<%= hyphenName %>>
-   </file>
-   </example>
-   *
-   */
-  angular
-      .module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>')
-      .directive('<%= lowerCamel %>', <%= lowerCamel %>);
+
+    /**
+    * @ngdoc directive
+    * @name <% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>.directive:<%= lowerCamel %>
+    * @restrict EA
+    * @element
+    *
+    * @description
+    *
+    * @example
+    <example module="<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>">
+    <file name="index.html">
+    <<%= hyphenName %>></<%= hyphenName %>>
+    </file>
+    </example>
+    *
+    */
+    angular
+        .module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>')
+        .directive('<%= lowerCamel %>', <%= upperCamel %>Directive);
+}

--- a/lib/directive/templates/_directive.ts
+++ b/lib/directive/templates/_directive.ts
@@ -1,7 +1,10 @@
 ///<reference path='<%= referencePath %>' />
 module <%= upperCamel %> {
     'use strict';
-
+    <% if (!controllerAs) { %>
+    interface I<%= upperCamel %>Scope extends ng.IScope {
+        <%= lowerCamel %>: any,
+    }<% } %>
     function <%= upperCamel %>Directive(): ng.IDirective {
         return {
             restrict: 'EA',
@@ -11,15 +14,14 @@ module <%= upperCamel %> {
             replace: false,<% if (controllerAs) { %>
             controllerAs: '<%= lowerCamel %>',<% } %>
             controller: <% if (!controllerAs) { %>
-                function($scope: ng.IScope) {
+                function($scope: I<%= upperCamel %>Scope): void {
                     $scope.<%= lowerCamel %> = {};
                     $scope.<%= lowerCamel %>.name = '<%= lowerCamel %>';
-                }
-                <% } else { %><%= upperCamel %>Controller<% } %>,
-            link: function (scope: ng.IScope, element: JQuery, attrs: any) {
+                },<% } else { %><%= upperCamel %>Controller,<% } %>
+            link: function (scope: ng.IScope, element: JQuery, attrs: any): void {
                 /*jshint unused:false */
                 /*eslint "no-unused-vars": [2, {"args": "none"}]*/
-            }
+            },
         }
     }
     <% if (controllerAs) { %>
@@ -41,11 +43,11 @@ module <%= upperCamel %> {
     * @description
     *
     * @example
-    <example module="<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>">
-    <file name="index.html">
-    <<%= hyphenName %>></<%= hyphenName %>>
-    </file>
-    </example>
+    *   <example module="<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>">
+    *       <file name="index.html">
+    *           <<%= hyphenName %>></<%= hyphenName %>>
+    *       </file>
+    *   </example>
     *
     */
     angular

--- a/lib/directive/templates/_directive.ts
+++ b/lib/directive/templates/_directive.ts
@@ -1,44 +1,51 @@
 ///<reference path='<%= referencePath %>' />
-module <%= upperCamel %> {
+function <%= upperCamel %>Directive(): ng.IDirective {
   'use strict';
-
-  /**
-  * @ngdoc directive
-  * @name <% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>.directive:<%= lowerCamel %>
-  * @restrict EA
-  * @element
-  *
-  * @description
-  *
-  * @example
-    <example module="<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>">
-      <file name="index.html">
-        <<%= hyphenName %>></<%= hyphenName %>>
-      </file>
-    </example>
-  *
-  */
-  angular
-    .module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>')
-    .directive('<%= lowerCamel %>', <%= lowerCamel %>);
-
-  function <%= lowerCamel %>(): ng.IDirective {
-    return {
-      restrict: 'EA',
-      scope: {}<% if (directiveTemplateUrl) { %>,
-      templateUrl: '<%= templateUrl %>/<%= hyphenName %>-directive.tpl.html'<% } else { %>,
-      template: '<div>{{<%= lowerCamel %>.name}}</div>'<% } %>,
-      replace: false,<% if (controllerAs) { %>
-      controllerAs: '<%= lowerCamel %>',<% } %>
-      controller: function (<% if (!controllerAs) { %>$scope: ng.IScope<% } %>) {
+  return {
+        restrict: 'EA',
+        scope: {},<% if (directiveTemplateUrl) { %>
+        templateUrl: '<%= templateUrl %>/<%= hyphenName %>-directive.tpl.html'<% } else { %>,
+        template: '<div>{{<%= lowerCamel %>.name}}</div>'<% } %>,
+        replace: false,<% if (controllerAs) { %>
+        controllerAs: '<%= lowerCamel %>',
+        controller: function (<% if (!controllerAs) { %>$scope: ng.IScope<% } %>) {
         <% if (controllerAs) { %>var vm = this;
-        vm.name = '<%= lowerCamel %>';<% } else { %>$scope.<%= lowerCamel %> = {};
-        $scope.<%= lowerCamel %>.name = '<%= lowerCamel %>';<% } %>
-      },
-      link: function (scope: ng.IScope, element: JQuery, attrs: any) {
-        /*jshint unused:false */
-        /*eslint "no-unused-vars": [2, {"args": "none"}]*/
-      }
-    };
+            vm.name = '<%= lowerCamel %>';<% } else { %>$scope.<%= lowerCamel %> = {};
+            $scope.<%= lowerCamel %>.name = '<%= lowerCamel %>';<% } %>
+    },
+    link: (scope: ng.IScope, element: JQuery, attrs: ng.IAttributes): void => {
+      /*jshint unused:false */
+      /*eslint "no-unused-vars": [2, {"args": "none"}]*/
+    }
   }
 }
+  <% if (!controllerAs) { %>
+    module <%= upperCamel %> {
+          'use strict';
+  export class <%= upperCamel %>Controller {
+    public static $inject: Array<string> = [];
+      constructor() {
+        /*jshint unused:false */
+      }
+    }
+  }
+    <% } %>
+  /**
+   * @ngdoc directive
+   * @name <% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>.directive:<%= lowerCamel %>
+   * @restrict EA
+   * @element
+   *
+   * @description
+   *
+   * @example
+   <example module="<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>">
+   <file name="index.html">
+   <<%= hyphenName %>></<%= hyphenName %>>
+   </file>
+   </example>
+   *
+   */
+  angular
+      .module('<% if (parentModuleName) { %><%= parentModuleName %>.<% } %><%= moduleName %>')
+      .directive('<%= lowerCamel %>', <%= lowerCamel %>);

--- a/lib/directive/templates/_directive.ts
+++ b/lib/directive/templates/_directive.ts
@@ -10,22 +10,24 @@ module <%= upperCamel %> {
             template: '<div>{{<%= lowerCamel %>.name}}</div>'<% } %>,
             replace: false,<% if (controllerAs) { %>
             controllerAs: '<%= lowerCamel %>',<% } %>
-            controller: function (<% if (!controllerAs) { %>$scope: ng.IScope<% } %>) {
-                <% if (controllerAs) { %>var vm = this;
-                vm.name = '<%= lowerCamel %>';<% } else { %>$scope.<%= lowerCamel %> = {};
-                $scope.<%= lowerCamel %>.name = '<%= lowerCamel %>';<% } %>
-            },
+            controller: <% if (!controllerAs) { %>
+                function($scope: ng.IScope) {
+                    $scope.<%= lowerCamel %> = {};
+                    $scope.<%= lowerCamel %>.name = '<%= lowerCamel %>';
+                }
+                <% } else { %><%= upperCamel %>Controller<% } %>,
             link: function (scope: ng.IScope, element: JQuery, attrs: any) {
                 /*jshint unused:false */
                 /*eslint "no-unused-vars": [2, {"args": "none"}]*/
             }
         }
     }
-    <% if (!controllerAs) { %>
+    <% if (controllerAs) { %>
         export class <%= upperCamel %>Controller {
+            public name: string;
             public static $inject: Array<string> = [];
             constructor() {
-                /*jshint unused:false */
+                this.name = '<%= lowerCamel %>';
             }
         }
     <% } %>

--- a/lib/service/templates/_service.ts
+++ b/lib/service/templates/_service.ts
@@ -3,7 +3,7 @@ module <%= upperCamel %> {
   'use strict';
 
   class <%= upperCamel %> {
-    public static $inject = [
+    public static $inject: Array<string> = [
     ];
 
     constructor() {


### PR DESCRIPTION
#### What does this PR do?
This changes the way directives are created to use TypeScript classes when using the **controllerAs** syntax.

If the project uses **controllerAs** syntax, it creates the class and binds it as a controller to the directive object.

If the project don't use **controllerAs** syntax, it just creates the function as before, but creates the custom scope typing as an interface, extending the ng.IScope object.

#### Where should the reviewer start?
It should see that the directives are now using classes when using **controllerAs**

#### How should this be manually tested?
- Create a new project
- Select **TypeScript** and **controllerAs** 
- Create a new directive 
- Check that the created directive is using a class as a controller, which has a **name** and **$inject** properties.
- Check that the directive  works correctly and can be used in a template

- Create a new project
- Select **TypeScript** and NOT **controllerAs** 
- Create a new directive 
- Check that the created directive is uses a function, with the proper Interface created for the typedef


#### Documents
Example of a directive named **exampleComponent** created with **controllerAs** syntax:

![screenshot from 2016-06-02 12-41-47](https://cloud.githubusercontent.com/assets/3155133/15742484/7d15c988-28bf-11e6-8ae9-f0ee273bbdb3.png)
